### PR TITLE
Docker development or basic deployment environment, modified LISTEN_H…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3
+
+WORKDIR /usr/src/app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD [ "python", "./app.py" ]

--- a/app.py
+++ b/app.py
@@ -69,6 +69,6 @@ def index(request):
 if __name__ == "__main__":
     # Has run from the command line.
     # This section will not be called if run via Gunicorn or mod_wsgi
-    LISTEN_HOST = "127.0.0.1"
+    LISTEN_HOST = "0.0.0.0"
     LISTEN_PORT = 8080
     app.run(LISTEN_HOST, LISTEN_PORT, debug=True, auto_reload=False)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.4'
+
+services:
+  api:
+    build: .
+    volumes:
+      - .:/usr/src/app
+    ports:
+      - 8080


### PR DESCRIPTION
…OST to 0.0.0.0

The idea is so we can deploy and develop on machines that don't have python 3.6+ installed

Not sure if I've adversely effected things by changing the port to 0.0.0.0. 

