### PR TITLE
Add a get_resource endpoint at /resource

### DIFF
--- a/api.py
+++ b/api.py
@@ -6,7 +6,8 @@ from sanic.request import Request
 from sanic.exceptions import ServiceUnavailable
 from sanic_restplus import Api, Resource, fields
 
-from functions import get_linksets, get_datasets, get_locations, get_location_is_within, get_location_contains
+from functions import get_linksets, get_datasets, get_locations, get_location_is_within, get_location_contains, \
+    get_resource
 
 url_prefix = 'api/v1'
 
@@ -16,6 +17,7 @@ api_v1 = Api(title="LOCI Integration API",
              default_mediatype="application/json",
              additional_css="/static/material_swagger.css")
 ns = api_v1.default_namespace
+
 
 @ns.route('/linksets')
 class Linkset(Resource):
@@ -60,6 +62,7 @@ class Dataset(Resource):
         }
         return json(response, status=200)
 
+
 @ns.route('/locations')
 class Location(Resource):
     """Operations on LOCI Locations"""
@@ -80,6 +83,21 @@ class Location(Resource):
             "locations": locations,
         }
         return json(response, status=200)
+
+
+@ns.route('/resource')
+class _Resource(Resource):
+    """Operations on LOCI Resource"""
+
+    @ns.doc('get_resource', params=OrderedDict([
+        ("uri", {"description": "Target LOCI Location/Feature URI",
+                 "required": True, "type": "string"}),
+    ]), security=None)
+    async def get(self, request, *args, **kwargs):
+        """Gets a LOCI Resource"""
+        resource_uri = str(next(iter(request.args.getlist('uri'))))
+        resource = await get_resource(resource_uri)
+        return json(resource, status=200)
 
 
 ## The following are non-standard usage of REST/Swagger.

--- a/functions.py
+++ b/functions.py
@@ -26,6 +26,84 @@ async def query_graphdb_endpoint(sparql, infer=True, same_as=True, limit=1000, o
 query_graphdb_endpoint.session = None
 
 
+async def get_resource(resource_uri):
+    """
+    :param resource_uri:
+    :type resource_uri: str
+    :return:
+    """
+    sparql = """\
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+SELECT DISTINCT ?p ?o ?p1 ?o1 ?p2 ?o2
+WHERE {
+    {
+        ?s rdf:subject <URI> ;
+           rdf:predicate ?p;
+           rdf:object ?o .
+        OPTIONAL { FILTER (isBlank(?o))
+            {
+                ?s2 rdf:subject ?o ;
+                rdf:predicate ?p;
+                rdf:object ?o1 .
+            }
+            UNION
+            { ?o ?p1 ?o1 . }
+            OPTIONAL { FILTER (isBlank(?o1))
+                ?o1 ?p2 ?o2 .
+            }
+        }
+    }
+    UNION
+    {
+        <URI> ?p ?o .
+        OPTIONAL { FILTER (isBlank(?o))
+            {
+                ?s3 rdf:subject ?o ;
+                rdf:predicate ?p;
+                rdf:object ?o1 .
+            }
+            UNION
+            { ?o ?p1 ?o1 . }
+            OPTIONAL { FILTER (isBlank(?o1))
+                ?o1 ?p2 ?o2 .
+            }
+        }
+    }
+}
+"""
+    sparql = sparql.replace("<URI>", "<{}>".format(str(resource_uri)))
+    resp = await query_graphdb_endpoint(sparql)
+    resp_object = {}
+    if 'results' not in resp:
+        return resp_object
+    bindings = resp['results']['bindings']
+    for b in bindings:
+        pred = b['p']['value']
+        obj = b['o']
+        if obj['type'] == "bnode":
+            try:
+                obj = resp_object[pred]
+            except KeyError:
+                resp_object[pred] = obj = {}
+            pred1 = b['p1']['value']
+            obj1 = b['o1']
+            if obj1['type'] == "bnode":
+                try:
+                    obj1 = obj[pred1]
+                except KeyError:
+                    obj[pred1] = obj1 = {}
+                pred2 = b['p2']['value']
+                obj2 = b['o2']['value']
+                obj1[pred2] = obj2
+            else:
+                obj1 = obj1['value']
+            obj[pred1] = obj1
+        else:
+            obj = obj['value']
+        resp_object[pred] = obj
+    return resp_object
+
+
 async def get_linksets(count=1000, offset=0):
     """
     :param count:


### PR DESCRIPTION
Implement last main endpoint before we do the reapportionment one
This one is a bit fancy. It gets predicates and objects from a resource if they exist in a reified or non-reified manner.
It also follows blank nodes down to two levels deep, and nests the results into a JSON struct.