### PR TITLE
use sanic docker as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 ENTRYPOINT [ "python3", "./app.py" ]
 
 FROM base AS devmode
-RUN pip install --no-cache-dir -r dev-requirements.txt
+#RUN pip install --no-cache-dir -r dev-requirements.txt
 RUN apk add --no-cache git
 RUN git -C loci-testdata pull || git clone https://github.com/CSIRO-enviro-informatics/loci-testdata.git
 ENTRYPOINT [ "tail", "-f", "/dev/null" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,16 @@
-FROM python:3 AS base
+FROM sanicframework/sanic:LTS AS base
 
 WORKDIR /usr/src/app
 
 COPY . .
+RUN pip install -U setuptools pip
 RUN pip install --no-cache-dir -r requirements.txt
 
-ENTRYPOINT [ "python", "./app.py" ]
+ENTRYPOINT [ "python3", "./app.py" ]
 
 FROM base AS devmode
 RUN pip install --no-cache-dir -r dev-requirements.txt
+RUN apk add --no-cache git
 RUN git -C loci-testdata pull || git clone https://github.com/CSIRO-enviro-informatics/loci-testdata.git
 ENTRYPOINT [ "tail", "-f", "/dev/null" ]
 


### PR DESCRIPTION
This PR proposes using the sanic LTS docker image as the base rather than pure python3.

Using the python image as the base, I encountered issues with regards to compiling uvloop. Others have experienced this with sanic also - see https://github.com/huge-success/sanic/issues/1660

A suggestion from that issue was to use "a base image that already has uvloop installed", e.g. sanic LTS image. This PR implements that change. Testing on my local dev machine, confirms that it is working.

Also commenting out a line as `dev-requirements.txt` isn't checked in yet.