### PR TITLE
Hierarchical overlap

### DIFF
--- a/api.py
+++ b/api.py
@@ -176,7 +176,7 @@ class Overlaps(Resource):
                         "required": False, "type": "boolean", "default": False}),
         ("within", {"description": "Include features this location is wholly within",
                     "required": False, "type": "boolean", "default": False}),
-        ("crosswalk", {"description": "When overlaps are found to a resource also find overlaps to any object that contains that resource",
+        ("crosswalk", {"description": "Find overlaps event across different spatial hierarchies, other parameters are ignored, proportion, areas, contained, within are all True and paging is not currently implemented",
                     "required": False, "type": "boolean", "default": False}),
         ("count", {"description": "Number of locations to return.",
                    "required": False, "type": "number", "format": "integer", "default": 1000}),

--- a/api.py
+++ b/api.py
@@ -176,7 +176,9 @@ class Overlaps(Resource):
                         "required": False, "type": "boolean", "default": False}),
         ("within", {"description": "Include features this location is wholly within",
                     "required": False, "type": "boolean", "default": False}),
-        ("crosswalk", {"description": "Find overlaps event across different spatial hierarchies, other parameters are ignored, proportion, areas, contained, within are all True and paging is not currently implemented",
+        ("output_type", {"description": "Restrict output uris to specified fully qualified uri",
+                    "required": False, "type": "string", "default": ''}),
+        ("crosswalk", {"description": "Find overlaps event across different spatial hierarchies, some other parameters are ignored: contained, within are all set to true and paging is not currently implemented",
                     "required": False, "type": "boolean", "default": False}),
         ("count", {"description": "Number of locations to return.",
                    "required": False, "type": "number", "format": "integer", "default": 1000}),
@@ -189,6 +191,10 @@ class Overlaps(Resource):
         count = int(next(iter(request.args.getlist('count', [1000]))))
         offset = int(next(iter(request.args.getlist('offset', [0]))))
         target_uri = str(next(iter(request.args.getlist('uri'))))
+        if 'output_featuretype_uri'  in request.args:
+            output_featuretype_uri = str(next(iter(request.args.getlist('output_featuretype_uri'))))
+        else:
+            output_featuretype_uri = None
         include_areas = str(next(iter(request.args.getlist('areas', ['false']))))
         include_proportion = str(next(iter(request.args.getlist('proportion', ['false']))))
         include_contains = str(next(iter(request.args.getlist('contains', ['false']))))
@@ -201,10 +207,10 @@ class Overlaps(Resource):
         crosswalk = crosswalk[0] in TRUTHS
         if crosswalk:
             include_within = False
-            meta, overlaps = await get_location_overlaps_crosswalk(target_uri, include_areas, include_proportion, include_within,
+            meta, overlaps = await get_location_overlaps_crosswalk(target_uri, output_featuretype_uri, include_areas, include_proportion, include_within,
                                                         include_contains, count, offset)
         else:
-            meta, overlaps = await get_location_overlaps(target_uri, include_areas, include_proportion, include_within,
+            meta, overlaps = await get_location_overlaps(target_uri, output_featuretype_uri, include_areas, include_proportion, include_within,
                                                         include_contains, count, offset)
 
         response = {

--- a/api.py
+++ b/api.py
@@ -211,7 +211,7 @@ class Overlaps(Resource):
                                                         include_contains, count, offset)
         else:
             meta, overlaps = await get_location_overlaps(target_uri, output_featuretype_uri, include_areas, include_proportion, include_within,
-                                                        include_contains, count, offset)
+                                                        include_contains, None, count, offset)
 
         response = {
             "meta": meta,

--- a/api.py
+++ b/api.py
@@ -6,7 +6,7 @@ from sanic.request import Request
 from sanic.exceptions import ServiceUnavailable
 from sanic_restplus import Api, Resource, fields
 
-from functions import get_linksets, get_datasets, get_locations, get_location_is_within, get_location_contains, get_resource, get_location_overlaps, get_at_location, search_location_by_label
+from functions import get_linksets, get_datasets, get_locations, get_location_is_within, get_location_contains, get_resource, get_location_overlaps_crosswalk, get_location_overlaps, get_at_location, search_location_by_label
 
 
 url_prefix = 'api/v1'
@@ -176,6 +176,8 @@ class Overlaps(Resource):
                         "required": False, "type": "boolean", "default": False}),
         ("within", {"description": "Include features this location is wholly within",
                     "required": False, "type": "boolean", "default": False}),
+        ("crosswalk", {"description": "When overlaps are found to a resource also find overlaps to any object that contains that resource",
+                    "required": False, "type": "boolean", "default": False}),
         ("count", {"description": "Number of locations to return.",
                    "required": False, "type": "number", "format": "integer", "default": 1000}),
         ("offset", {"description": "Skip number of locations before returning count.",
@@ -191,12 +193,20 @@ class Overlaps(Resource):
         include_proportion = str(next(iter(request.args.getlist('proportion', ['false']))))
         include_contains = str(next(iter(request.args.getlist('contains', ['false']))))
         include_within = str(next(iter(request.args.getlist('within', ['false']))))
+        crosswalk = str(next(iter(request.args.getlist('crosswalk', ['false']))))
         include_areas = include_areas[0] in TRUTHS
         include_proportion = include_proportion[0] in TRUTHS
         include_contains = include_contains[0] in TRUTHS
         include_within = include_within[0] in TRUTHS
-        meta, overlaps = await get_location_overlaps(target_uri, include_areas, include_proportion, include_within,
-                                                     include_contains, count, offset)
+        crosswalk = crosswalk[0] in TRUTHS
+        if crosswalk:
+            include_within = False
+            meta, overlaps = await get_location_overlaps_crosswalk(target_uri, include_areas, include_proportion, include_within,
+                                                        include_contains, count, offset)
+        else:
+            meta, overlaps = await get_location_overlaps(target_uri, include_areas, include_proportion, include_within,
+                                                        include_contains, count, offset)
+
         response = {
             "meta": meta,
             "overlaps": overlaps,

--- a/api.py
+++ b/api.py
@@ -191,8 +191,8 @@ class Overlaps(Resource):
         count = int(next(iter(request.args.getlist('count', [1000]))))
         offset = int(next(iter(request.args.getlist('offset', [0]))))
         target_uri = str(next(iter(request.args.getlist('uri'))))
-        if 'output_featuretype_uri'  in request.args:
-            output_featuretype_uri = str(next(iter(request.args.getlist('output_featuretype_uri'))))
+        if 'output_type'  in request.args:
+            output_featuretype_uri = str(next(iter(request.args.getlist('output_type'))))
         else:
             output_featuretype_uri = None
         include_areas = str(next(iter(request.args.getlist('areas', ['false']))))

--- a/app.py
+++ b/app.py
@@ -36,7 +36,7 @@ def create_app():
     |_____\___/ \____|___| |___|_| \_| |_| |_____\____|_| \_/_/   \_|_| \___/|_| \_\ /_/   \_|_|  |___|
     """
     app.config.SWAGGER_UI_DOC_EXPANSION = 'list'
-    app.config.RESPONSE_TIMEOUT = 480
+    app.config.RESPONSE_TIMEOUT = 4800
     # Register/Activate Sanic-CORS plugin with allow all origins
     _ = spf.register_plugin(cors, origins=r".*", automatic_options=True)
 

--- a/app.py
+++ b/app.py
@@ -36,7 +36,7 @@ def create_app():
     |_____\___/ \____|___| |___|_| \_| |_| |_____\____|_| \_/_/   \_|_| \___/|_| \_\ /_/   \_|_|  |___|
     """
     app.config.SWAGGER_UI_DOC_EXPANSION = 'list'
-
+    app.config.KEEP_ALIVE_TIMEOUT = '120'
     # Register/Activate Sanic-CORS plugin with allow all origins
     _ = spf.register_plugin(cors, origins=r".*", automatic_options=True)
 

--- a/app.py
+++ b/app.py
@@ -36,7 +36,7 @@ def create_app():
     |_____\___/ \____|___| |___|_| \_| |_| |_____\____|_| \_/_/   \_|_| \___/|_| \_\ /_/   \_|_|  |___|
     """
     app.config.SWAGGER_UI_DOC_EXPANSION = 'list'
-    app.config.KEEP_ALIVE_TIMEOUT = '120'
+    app.config.RESPONSE_TIMEOUT = 120
     # Register/Activate Sanic-CORS plugin with allow all origins
     _ = spf.register_plugin(cors, origins=r".*", automatic_options=True)
 

--- a/app.py
+++ b/app.py
@@ -5,8 +5,9 @@ LOCI Integrator API
 Copyright 2019 CSIRO Land and Water
 
 @author Ashley Sommer <Ashley.Sommer@csiro.au>
+@author Ben Leighton <Benjamin.Leighton@csiro.au>
 """
-__author__ = "Ashley Sommer"
+__authors__ = "Ashley Sommer, Ben Leighton"
 __email__ = "Ashley.Sommer@csiro.au"
 __maintainer__ = "Ashley Sommer <Ashley.Sommer@csiro.au>"
 __copyright__ = "Copyright 2019 CSIRO Land and Water"

--- a/app.py
+++ b/app.py
@@ -36,7 +36,7 @@ def create_app():
     |_____\___/ \____|___| |___|_| \_| |_| |_____\____|_| \_/_/   \_|_| \___/|_| \_\ /_/   \_|_|  |___|
     """
     app.config.SWAGGER_UI_DOC_EXPANSION = 'list'
-    app.config.RESPONSE_TIMEOUT = 120
+    app.config.RESPONSE_TIMEOUT = 480
     # Register/Activate Sanic-CORS plugin with allow all origins
     _ = spf.register_plugin(cors, origins=r".*", automatic_options=True)
 

--- a/errors.py
+++ b/errors.py
@@ -3,4 +3,4 @@
 from sanic import exceptions
 class ReportableAPIError(exceptions.ServerError):
     def __init__(self, message):
-        super().__init__(message)
+        super(ReportableAPIError, self).__init__(message)

--- a/functions.py
+++ b/functions.py
@@ -489,7 +489,7 @@ async def get_location_overlaps_crosswalk(from_uri, output_featuretype_uri, incl
     found_parents = {}
     if not base_unit_prefix in from_uri:
         #This must be a parent unit so get everything contained and find base units
-        my_area, all_contained = await get_all_overlaps(from_uri, None, include_contains=True, include_within=False)
+        my_area, all_contained = await get_all_overlaps(from_uri, None, None, include_contains=True, include_within=False)
         collated_uri_dict = {} 
         for an_contained in all_contained:
             from_base_uri = an_contained['uri'] 

--- a/functions.py
+++ b/functions.py
@@ -11,6 +11,42 @@ from json import loads
 
 from errors import ReportableAPIError
 
+#Until we have a better way of understanding fundamental units in spatial hierarchies
+prefix_base_unit_lookup = {
+"linked.data.gov.au/dataset/asgs2016" : "linked.data.gov.au/dataset/asgs2016/meshblock",
+"linked.data.gov.au/dataset/geofabric" : "linked.data.gov.au/dataset/geofabric/contractedcatchment"
+}
+
+async def get_other_base_unit_and_type_prefix(from_uri, query_uri):
+    '''
+    Find the base_unit and type prefix of a uri that is not of the from_uri type
+    and is of the query_uri type
+    '''
+    base_unit_prefix = None
+    resource_type_prefix = None
+    for key, value in prefix_base_unit_lookup.items():
+        if not key in from_uri:
+            if key in query_uri:
+                base_unit_prefix = value 
+                resource_type_prefix = key 
+                return base_unit_prefix, resource_type_prefix
+    return base_unit_prefix, resource_type_prefix
+
+async def get_all_overlaps(target_uri, include_contains=True, include_within=True):
+    offset = 0
+    all_overlaps = []
+    while True:
+        print(target_uri)
+        print(offset)
+        results = list(await get_location_overlaps(target_uri, True, True, include_within, include_contains, count=100000, offset=offset))
+        print(results[0])
+        length = results[0]['count']
+        my_area = results[0]['featureArea'] 
+        all_overlaps = all_overlaps + results[1]
+        if length < 100000:
+            break
+        offset += 100000
+    return my_area, all_overlaps
 
 async def query_graphdb_endpoint(sparql, infer=True, same_as=True, limit=1000, offset=0):
     """
@@ -154,6 +190,7 @@ WHERE {
     }
 }
 """
+    print(sparql)
     resp = await query_graphdb_endpoint(sparql, limit=count, offset=offset)
     linksets = []
     if 'results' not in resp:
@@ -165,6 +202,7 @@ WHERE {
         'count': len(linksets),
         'offset': offset,
     }
+    print(meta)
     return meta, linksets
 
 async def get_datasets(count=1000, offset=0):
@@ -355,6 +393,85 @@ async def query_build_response_bindings(sparql, count, offset, bindings):
             if len(resp['results']['bindings'][0].keys()) > 0:
                 bindings.extend(resp['results']['bindings'])
 
+async def get_location_overlaps_crosswalk(from_uri, include_areas, include_proportion, include_within, include_contains, include_count=1000, offset=0):
+    """
+    :param target_uri:
+    :type target_uri: str
+    :type include_areas: bool
+    :type include_proportion: bool
+    :type include_within: bool
+    :type include_contains: bool
+    :param count:
+    :type count: int
+    :param offset:
+    :type offset: int
+    :return:
+    """
+    # page through all the contained objects 
+    # for each response to end await get_location_overlap and gather until all got
+    # iterate over all responses
+    # if a "base unit" note the unit and the proportion of parent i.e target_uri made up by this unit 
+    # find things that overlap with this foundational unit that are other foundational units
+    # multiply the proportion of overlap of the overlapping unit by the proportion of the parent store this figure as the "passover distribution amount" 
+    # find the proportion the new foundational unit makes up of various parent units and multiple this by the "passover distribution" and store
+    # collate and sum all results for target units
+
+    base_unit_prefix, resource_type_prefix = await get_other_base_unit_and_type_prefix("", from_uri)
+    # this is a base unit so continue to base unit logic
+    parent_amount = {}
+    if not base_unit_prefix in from_uri:
+        #This must be a higher level unit so get everything contained
+        my_area, all_contained = await get_all_overlaps(from_uri, include_contains=True, include_within=False)
+        collated_uri_dict = {} 
+        for an_contained in all_contained:
+            from_base_uri = an_contained['uri'] 
+            if base_unit_prefix is None:
+                continue
+            if not base_unit_prefix in from_base_uri:
+                continue
+            amount_within_from_uri = an_contained["reverseProportion"]
+            # found a base uri do base uri logic 
+            await get_location_overlaps_crosswalk_base_uri(parent_amount, amount_within_from_uri, from_base_uri)
+    else:
+        my_area = await get_location_overlaps_crosswalk_base_uri(parent_amount, 1, from_uri)
+    # have a bunch of parents and lots of records abount how much of the fractions of base units that belong to the original unit
+    # belong to them, need to sum up all those per parent and build results list 
+
+    parents = parent_amount.values()
+    for aparent in parents:
+        aparent["reverseProportion"]  = str(aparent["reverseProportion"] ) 
+    meta = {
+        'count': len(parents),
+        'offset': 0,
+    }
+    if my_area and include_areas:
+        meta['featureArea'] = my_area
+    return meta, list(parents)
+
+async def get_location_overlaps_crosswalk_base_uri(parent_amount, proportion_original_uri, from_base_uri):
+    my_area, all_overlaps = await get_all_overlaps(from_base_uri, include_contains=True, include_within=True)
+    for an_overlap in all_overlaps:
+        other_base_uri = an_overlap["uri"]
+        base_unit_prefix, resource_type_prefix = await get_other_base_unit_and_type_prefix(from_base_uri, other_base_uri)
+        if base_unit_prefix is None:
+            continue
+        if not base_unit_prefix in other_base_uri:
+            continue
+        # found an overlapping base unit
+        amount_within_from_base_uri = an_overlap["reverseProportion"]
+        # find all its parents
+        my_area, all_within = await get_all_overlaps(other_base_uri, include_contains=False, include_within=True)
+        for an_within in all_within:
+            within_uri = an_within["uri"]
+            feature_area = an_within["featureArea"]
+            if not resource_type_prefix in within_uri:
+                continue
+            # this is a parent of the other_base_unit
+            if not within_uri in parent_amount.keys(): 
+                parent_amount[within_uri] = { "uri" : within_uri, "featureArea" : feature_area, "reverseProportion" : 0  } 
+            parent_amount[within_uri]["reverseProportion"] += (float(amount_within_from_base_uri) / 100 * float(proportion_original_uri))
+    return my_area 
+
 
 async def get_location_overlaps(target_uri, include_areas, include_proportion, include_within, include_contains, count=1000, offset=0):
     """
@@ -522,7 +639,7 @@ GROUP BY ?o
         sparql = sparql.replace("<URI>", "<{}>".format(str(target_uri)))
         await query_build_response_bindings(sparql, count, offset, bindings)
     if len(bindings) < 1:
-        return {'count', 0}, overlaps
+        return {'count': 0, 'offset': offset}, overlaps
     if not include_proportion and not include_areas:
         my_area = False
         for b in bindings:

--- a/functions.py
+++ b/functions.py
@@ -461,7 +461,7 @@ async def get_location_overlaps_crosswalk(from_uri, output_featuretype_uri, incl
         collated_uri_dict = {} 
         for an_contained in all_contained:
             from_base_uri = an_contained['uri'] 
-            if base_unit_prefixes in None:
+            if base_unit_prefix is None:
                 continue
             if not base_unit_prefix in from_base_uri:
                 # isn't actually a base uri but record information 

--- a/functions.py
+++ b/functions.py
@@ -457,8 +457,12 @@ async def get_location_overlaps_crosswalk_base_uri(parent_amount, proportion_ori
             continue
         if not base_unit_prefix in other_base_uri:
             continue
+        other_feature_area = an_overlap["featureArea"]
         # found an overlapping base unit
         amount_within_from_base_uri = an_overlap["reverseProportion"]
+        if not other_base_uri in parent_amount.keys(): 
+            parent_amount[other_base_uri] = { "uri" : other_base_uri, "featureArea" : other_feature_area, "reverseProportion" : 0 } 
+        parent_amount[other_base_uri]["reverseProportion"] += (float(amount_within_from_base_uri) / 100 * float(proportion_original_uri))
         # find all its parents
         my_area, all_within = await get_all_overlaps(other_base_uri, include_contains=False, include_within=True)
         for an_within in all_within:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 sanic>=19.6.0,<19.7
 sanic-plugins-framework>=0.8.2,<0.9
 sanic-cors>=0.9.9,<0.10
-sanic-restplus>=0.4.0,<0.5
+sanic-restplus>=0.4.1,<0.5
 aiohttp>=3.5.0,<3.6
 asyncpg>=0.18.3,<0.19

--- a/test_basic.py
+++ b/test_basic.py
@@ -44,8 +44,8 @@ async def test_overlaps_within(test_cli, get_data):
         logging.debug("Expected Proportion {}".format(result_proportion))
         assert result_uri in results_uris.keys()
         logging.debug(results_uris[result_uri])
-        if "forwardProportion" in results_uris[result_uri].keys(): 
-            returned_proportion = float(results_uris[result_uri]["forwardProportion"])
+        if "forwardPercentage" in results_uris[result_uri].keys(): 
+            returned_proportion = float(results_uris[result_uri]["forwardPercentage"])
             logging.debug("Returned Proportion {}".format(returned_proportion))
             assert  returned_proportion == pytest.approx(result_proportion, 0.001)
     assert resp.status == 200


### PR DESCRIPTION
This implements U shaped queries. It definitely needs review and maybe modification. If we decide to merge it to master we should focus on making sure existing functionality when "crosswalk" is false is preserved so as not to regress. In any case either on this branch or in the future it will need work. 

- it does use URI based lookups for linksets where really it should be detecting them via SPARQL queries
- there is some duplicated code in @ashleysommer  original overlaps SPARQL
- the code is fairly messy because I've been adding functionality and patching bugs rather than thinking about how to make it elegant
- we need to think about how to do "linkset" filtering when and if we move to direct (non reified) linkset relationships @ashleysommer has done some future proofing of code for this and I've not tried to inject filtering in there but the code isn't used yet
- there are some questionable mismatches in internal numbers I'm seeing in your test query @Shane Seaton ~880 meshblocks overlap in the response but it looks as if >900 meshblocks overlap internally
- We should filter up the other side of the U previously I thought we'd need to do something complex to do this filtering e.g if you wanted DrainageDivision you'd still need to get RiverRegion but reading through Shane's pseudo code it dawned on me we actually don't need that e.g aggregations only need ContractedCatchments and can directly go to Drainage divisions, the logic conforms to this at the moment but the filtering bit isn't there. We need to modify the core overlaps functions to accept types for within / contains / overlaps bits of the SPARQL