### PR TITLE
Dependency updates

### DIFF
--- a/api.py
+++ b/api.py
@@ -9,7 +9,7 @@ from sanic_restplus import Api, Resource, fields
 from functions import get_linksets, get_datasets, get_locations, get_location_is_within, get_location_contains, get_resource, get_location_overlaps_crosswalk, get_location_overlaps, get_at_location, search_location_by_label
 
 
-url_prefix = 'api/v1'
+url_prefix = '/v1'
 
 api_v1 = Api(title="LOCI Integration API",
              version="1.2",

--- a/app.py
+++ b/app.py
@@ -30,10 +30,10 @@ def create_app():
     app = Sanic(__name__)
     spf = SanicPluginsFramework(app)
     app.config['LOGO'] = r"""
-     _     ___   ____ ___   ___ _   _ _____ _____ ____ ____     _  _____ ___  ____       _    ____ ___ 
+     _     ___   ____ ___   ___ _   _ _____ _____ ____ ____     _  _____ ___  ____       _    ____ ___
     | |   / _ \ / ___|_ _| |_ _| \ | |_   _| ____/ ___|  _ \   / \|_   _/ _ \|  _ \     / \  |  _ |_ _|
-    | |  | | | | |    | |   | ||  \| | | | |  _|| |  _| |_) | / _ \ | || | | | |_) |   / _ \ | |_) | | 
-    | |__| |_| | |___ | |   | || |\  | | | | |__| |_| |  _ < / ___ \| || |_| |  _ <   / ___ \|  __/| | 
+    | |  | | | | |    | |   | ||  \| | | | |  _|| |  _| |_) | / _ \ | || | | | |_) |   / _ \ | |_) | |
+    | |__| |_| | |___ | |   | || |\  | | | | |__| |_| |  _ < / ___ \| || |_| |  _ <   / ___ \|  __/| |
     |_____\___/ \____|___| |___|_| \_| |_| |_____\____|_| \_/_/   \_|_| \___/|_| \_\ /_/   \_|_|  |___|prod
     """
     app.config.SWAGGER_UI_DOC_EXPANSION = 'list'
@@ -42,9 +42,10 @@ def create_app():
     _ = spf.register_plugin(cors, origins=r".*", automatic_options=True)
 
     # Register/Activate Sanic-Restplus plugin
-    restplus_associated = spf.register_plugin(restplus)
+    restplus_associated = spf.register_plugin(restplus, _url_prefix="api")
 
     # Remove any previous apps from the api instance.
+    # (this is needed during testing, the test runner does calls create_app many times)
     api_v1.spf_reg = None
 
     # Register our LOCI Api on the restplus plugin

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-sanic>=19.6.0,<19.7
-sanic-plugins-framework>=0.8.2,<0.9
-sanic-cors>=0.9.9,<0.10
-sanic-restplus>=0.4.1,<0.5
+sanic>=19.12.2,<19.13
+sanic-plugins-framework>=0.9.0,<0.10
+sanic-cors>=0.10.0,<0.11
+sanic-restplus>=0.5.1,<0.6
 aiohttp>=3.5.0,<3.6
 asyncpg>=0.18.3,<0.19

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 sanic>=19.12.2,<19.13
 sanic-plugins-framework>=0.9.0,<0.10
-sanic-cors>=0.10.0,<0.11
+sanic-cors>=0.10.0.post1,<0.11
 sanic-restplus>=0.5.1,<0.6
 aiohttp>=3.5.0,<3.6
 asyncpg>=0.18.3,<0.19


### PR DESCRIPTION
Bump version of Sanic to 19.12.2, and corresponding updates to latest sanic-cors and latest sanic-restplus.

Also move the `/api/` route prefix to a the restplus plugin auto-prefix.