### PR TITLE
use https

### DIFF
--- a/config.py
+++ b/config.py
@@ -14,4 +14,4 @@ ES_ENDPOINT = CONFIG["ES_ENDPOINT"] = \
     "{}:{}/_search".format(ES_URL, ES_PORT)
 
 
-GEOM_DATA_SVC_ENDPOINT = CONFIG["GEOM_DATA_SVC_ENDPOINT"] = "http://gds.loci.cat"
+GEOM_DATA_SVC_ENDPOINT = CONFIG["GEOM_DATA_SVC_ENDPOINT"] = "https://gds.loci.cat"


### PR DESCRIPTION
Results coming back from find_at_location currently use HTTP but clients like https://explorer.loci.cat fails to get geoms because the link to the resource is HTTP rather than HTTPS.

We've now enabled HTTPS with GDS, but to reflect this, the call must use HTTPS instead of HTTP. A simple fix in the config does the job.