### PR TITLE
Add config for local ssl certs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -278,3 +278,5 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
+*.pem
+*.crt

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,3 +1,6 @@
-api2.loci.cat
-tls Ben.Leighton@csiro.au
-proxy / http://api:8080
+api.loci.cat
+tls /etc/ssl/wildcard-loci-cat.bundle.pem /etc/ssl/wildcard-loci-cat.pem
+proxy / http://api:8080 {
+   transparent
+}
+cors

--- a/certs/README.md
+++ b/certs/README.md
@@ -1,0 +1,5 @@
+SSL Certs go in this directory...
+
+Expects `wildcard-loci-cat.bundle.pem` and `wildcard-loci-cat.pem`
+But obviously don't commit them to this directory!
+

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -17,7 +17,7 @@ services:
       - ACME_AGREE=true
     volumes:
       - ./Caddyfile:/etc/Caddyfile
-      - /certs:/root/.caddy
+      - ./certs:/etc/ssl
     links:
       - api
     restart: always


### PR DESCRIPTION
This PR features configs for using our own HTTPS/SSL certificates rather than letsencrypt (which is the default for Caddy).

Updates to the Caddyfile to include CORS, and transparent URLs from the proxy included also.