### PR TITLE
API doc fix and CRS

### DIFF
--- a/api.py
+++ b/api.py
@@ -202,7 +202,7 @@ class Contains(Resource):
 class Overlaps(Resource):
     """Function for location Overlaps"""
 
-    @ns.doc('get_location_contains', params=OrderedDict([
+    @ns.doc('get_location_overlaps', params=OrderedDict([
         ("uri", {"description": "Target LOCI Location/Feature URI",
                  "required": True, "type": "string"}),
         ("areas", {"description": "Include areas of overlapping features in m2",
@@ -261,7 +261,7 @@ class Overlaps(Resource):
 class find_at_location(Resource):
     """Function for location find by point"""
 
-    @ns.doc('get_location_contains', params=OrderedDict([
+    @ns.doc('find_at_location', params=OrderedDict([
         ("loci_type", {"latitude": "Loci location type to query, can be 'any', 'mb' for meshblocks or 'cc' for contracted catchments",
                  "required": False, "type": "string", "default":"any"}),
         ("lat", {"latitude": "Query point latitude",

--- a/api.py
+++ b/api.py
@@ -284,7 +284,7 @@ class find_at_location(Resource):
         lat = float(next(iter(request.args.getlist('lat', None))))
         crs = int(next(iter(request.args.getlist('crs', [4326]))))
         loci_type = str(next(iter(request.args.getlist('loci_type', 'mb'))))
-        meta, locations = await get_at_location(lat, lon, loci_type, count, offset)
+        meta, locations = await get_at_location(lat, lon, loci_type, crs, count, offset)
         response = {
             "meta": meta,
             "locations": locations,

--- a/api.py
+++ b/api.py
@@ -267,19 +267,22 @@ class find_at_location(Resource):
         ("lat", {"latitude": "Query point latitude",
                  "required": True, "type": "number", "format": "float"}),
         ("lon", {"longitude": "Query point longitude",
-                   "required": False, "type": "number", "format": "float"}),
+                   "required": True, "type": "number", "format": "float"}),
+        ("crs", {"crs": "Query point CRS. Default is 4326 (WGS 84)",
+                   "required": False, "type": "number", "format" : "integer", "default": 4326}),
         ("count", {"description": "Number of locations to return.",
                    "required": False, "type": "number", "format": "integer", "default": 1000}),
         ("offset", {"description": "Skip number of locations before returning count.",
                     "required": False, "type": "number", "format": "integer", "default": 0}),
     ]), security=None)
     async def get(self, request, *args, **kwargs):
-        """Gets all LOCI Locations that this target LOCI URI overlaps with\n
+        """Finds all LOCI features that intersect with this location, specified by the coordinates\n
         Note: count and offset do not currently work properly on /overlaps """
         count = int(next(iter(request.args.getlist('count', [1000]))))
         offset = int(next(iter(request.args.getlist('offset', [0]))))
         lon = float(next(iter(request.args.getlist('lon', None))))
         lat = float(next(iter(request.args.getlist('lat', None))))
+        crs = int(next(iter(request.args.getlist('crs', [4326]))))
         loci_type = str(next(iter(request.args.getlist('loci_type', 'mb'))))
         meta, locations = await get_at_location(lat, lon, loci_type, count, offset)
         response = {

--- a/functions.py
+++ b/functions.py
@@ -945,12 +945,14 @@ GROUP BY ?o
     return meta, final_overlaps
 
 
-async def get_at_location(lat, lon, loci_type="any", count=1000, offset=0):
+async def get_at_location(lat, lon, loci_type="any", crs=4326, count=1000, offset=0):
     """
     :param lat:
     :type lat: float
     :param lon:
     :type lon: float
+    :param crs:
+    :type crs: int
     :param count:
     :type count: int
     :param offset:
@@ -967,7 +969,8 @@ async def get_at_location(lat, lon, loci_type="any", count=1000, offset=0):
     results = {}
     counter = 0
     params = {
-       "_format" : "application/json"
+       "_format" : "application/json",
+       "crs": crs
     }
     formatted_resp = {
         'ok': False


### PR DESCRIPTION
Fixes a bug and adds an enhancement.

Bug: OpenAPI/Swagger UI opens 3 panels when only one selected (e.g. /location/find_at_location). Fix is unique IDs needed for each endpoint.

Enhancement: /location/find_at_location now has a CRS parameter, with default being 4326 (WGS 84).
