### PR TITLE
update link to new location labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,19 @@ if running the api with docker image from docker hub
 `docker-compose -f docker-compose.yml -f docker-compose.useimage.yml up -d` 
 
 
+## Known issues
+
+If running the elasticsearch appliance throws up an error like:
+```
+initial heap size [2685456] not equal to maximum heap size [2147483648]; this can cause resize pauses and prevents mlockall from locking the entire heap
+```
+
+Ensure this is updated on the OS like so...
+```
+$ sudo sysctl -w vm.max_map_count=262144
+
+```
+
 ## License
 The license of this document is TBD
 

--- a/docker-compose.es.yml
+++ b/docker-compose.es.yml
@@ -5,7 +5,7 @@ services:
     build: ./search
     environment:
       #full set of labels
-      - S3_LABEL_TARBALL=http://loci-assets.s3.ap-southeast-2.amazonaws.com/location_labels/loc-labels-es-json.tar.gz
+      - S3_LABEL_TARBALL=http://loci-assets.s3.ap-southeast-2.amazonaws.com/location_labels/loc-labels-es-json_20200603.tar.gz
       #test set of labels
       #- S3_LABEL_TARBALL=http://loci-assets.s3.ap-southeast-2.amazonaws.com/location_labels/loc-labels-es-json-testdata.tar.gz
     command: sh -c './wait-for-it.sh elasticsearch:9200 -t 0 -- ./load_es.sh'

--- a/search/load_es.sh
+++ b/search/load_es.sh
@@ -38,7 +38,7 @@ do
   echo "Processing $f file..."
   # take action on each file. $f store current file name
   echo "uploading $f to es"
-  curl -s -XPOST -H "Content-Type: application/json" elasticsearch:9200/_bulk --data-binary @${f} 
+  curl --silent --output /dev/null -XPOST -H "Content-Type: application/json" elasticsearch:9200/_bulk --data-binary @${f} 
   #cleanup
   rm $f
 done


### PR DESCRIPTION
The latest cache content introduced new Feature instances. Since then, new location labels have been harvested and uploaded to the AWS S3 bucket. This PR updates the URL to the location label tar ball.